### PR TITLE
Flask App and Docker Setup for AI Compliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-EXPOSE 5000
+EXPOSE 5005
 
-CMD ["gunicorn", "-b", "0.0.0.0:5000", "app:app"]
+CMD ["gunicorn", "-b", "0.0.0.0:5005", "app:app"]

--- a/RUN.md
+++ b/RUN.md
@@ -7,12 +7,12 @@ docker build -t ai-compliance .
 
 Run the container:
 ```bash
-docker run -p 5000:5000 ai-compliance
+docker run -p 5005:5005 ai-compliance
 ```
 
 Then open your browser and go to:
 ```
-http://localhost:5000
+http://localhost:5005
 ```
 
 This will serve the Flask app on port 5000 using Gunicorn.


### PR DESCRIPTION
This PR adds a Flask-based application with Docker support:

- Converts `index 3.html` into a Flask app
- Adds `app.py`, `templates/index.html`, and `requirements.txt`
- Adds Dockerfile with port 5005 and Gunicorn
- Adds .dockerignore
- Adds RUN.md with instructions for local Docker deployment