### PR TITLE
Fix tool schema

### DIFF
--- a/app.py
+++ b/app.py
@@ -215,39 +215,37 @@ TOOLS = [
     },
     {
         "type": "function",
-        "function": {
-            "name": "fcc_search_filings",
-            "description": "Search FCC ECFS for all PDF attachments of a company",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "company": {
-                        "type": "string",
-                        "description": "Company name to search for",
-                    },
+        "name": "fcc_search_filings",
+        "description": "Search FCC ECFS for all PDF attachments of a company",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "company": {
+                    "type": "string",
+                    "description": "Company name to search for",
                 },
-                "required": ["company"],
             },
+            "required": ["company"],
         },
+        "strict": True,
     },
     {
         "type": "function",
-        "function": {
-            "name": "fcc_get_filings_text",
-            "description": "Download & parse selected FCC ECFS PDFs and return text",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "company": {"type": "string"},
-                    "indexes": {
-                        "type": "array",
-                        "items": {"type": "integer"},
-                        "description": "1-based indexes from fcc_search_filings",
-                    },
+        "name": "fcc_get_filings_text",
+        "description": "Download & parse selected FCC ECFS PDFs and return text",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "company": {"type": "string"},
+                "indexes": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "1-based indexes from fcc_search_filings",
                 },
-                "required": ["company", "indexes"],
             },
+            "required": ["company", "indexes"],
         },
+        "strict": True,
     },
 ]
 


### PR DESCRIPTION
## Summary
- fix tool dictionaries so all include `name` and use top-level attributes

## Testing
- `python -m py_compile app.py`
- *(fails: `ModuleNotFoundError: No module named 'httpx'` when trying to run `python app.py`)*